### PR TITLE
Add last-seen display

### DIFF
--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -67,6 +67,8 @@ OC.L10N.register(
     "Invisible" : "Невидимка",
     "Offline" : "Не в сети",
     "You missed a call from {user}" : "Вы пропустили вызов от {user}",
-    "You missed a group call in {call}" : "Вы пропустили вызов в обсуждении {call}"
+    "You missed a group call in {call}" : "Вы пропустили вызов в обсуждении {call}",
+    "Last online" : "Был в сети",
+    "Last online {time}" : "Был в сети {time} назад"
 },
 "nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);");

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -65,6 +65,8 @@
     "Invisible" : "Невидимка",
     "Offline" : "Не в сети",
     "You missed a call from {user}" : "Вы пропустили вызов от {user}",
+    "Last online" : "Был в сети",
+    "Last online {time}" : "Был в сети {time} назад",
     "You missed a group call in {call}" : "Вы пропустили вызов в обсуждении {call}"
 },"pluralForm" :"nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);"
 }

--- a/src/talk/renderer/TalkWrapper/talk.service.ts
+++ b/src/talk/renderer/TalkWrapper/talk.service.ts
@@ -5,6 +5,11 @@
 
 import { isNavigationFailure, NavigationFailureType } from '@talk/node_modules/vue-router'
 import { useTalkHashStore } from '@talk/src/stores/talkHash.js'
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+import { CONVERSATION } from '@talk/src/constants.ts'
+import { useLastSeenStore } from '../UserStatus/lastSeen.store.ts'
+import { fetchUserLastSeen } from '../UserStatus/publicUserStatus.service.ts'
 
 /**
  * Get the Talk instance
@@ -46,13 +51,26 @@ export function openRoot() {
  * @param options.directCall - Use direct call (open media settings to join a call)
  */
 export async function openConversation(token: string, { directCall = false }: { directCall?: boolean } = {}) {
-	await getTalkRouter().push({
-		name: 'conversation',
-		params: { token },
-		hash: directCall ? '#direct-call' : undefined,
-	}).catch(passDuplicatedNavigationError)
+       await getTalkRouter().push({
+               name: 'conversation',
+               params: { token },
+               hash: directCall ? '#direct-call' : undefined,
+       }).catch(passDuplicatedNavigationError)
 
-	await window.TALK_DESKTOP.focusTalk()
+       await window.TALK_DESKTOP.focusTalk()
+
+       try {
+               const response = await axios.get(generateOcsUrl('apps/spreed/api/v4/room/{token}', { token }))
+               const conversation = response.data.ocs.data
+               if (conversation.type === CONVERSATION.TYPE.ONE_TO_ONE || conversation.type === CONVERSATION.TYPE.ONE_TO_ONE_FORMER) {
+                       const otherId = conversation.name
+                       const store = useLastSeenStore()
+                       const lastSeen = await fetchUserLastSeen(otherId)
+                       store.setLastSeen(otherId, lastSeen)
+               }
+       } catch (error) {
+               console.error('Failed to fetch last seen', error)
+       }
 }
 
 /**

--- a/src/talk/renderer/UserStatus/components/LastSeen.vue
+++ b/src/talk/renderer/UserStatus/components/LastSeen.vue
@@ -1,0 +1,31 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { t } from '@nextcloud/l10n'
+import { formatRelativeTimeFromNow } from '../../../shared/datetime.utils.ts'
+
+const props = defineProps<{ lastSeen: number | null }>()
+
+const lastSeenLabel = computed(() => {
+    if (!props.lastSeen) {
+        return t('talk_desktop', 'Last online')
+    }
+    const time = formatRelativeTimeFromNow(props.lastSeen * 1000)
+    return t('talk_desktop', 'Last online {time}', { time })
+})
+</script>
+
+<template>
+    <span class="last-seen">{{ lastSeenLabel }}</span>
+</template>
+
+<style scoped>
+.last-seen {
+    opacity: 0.6;
+    font-size: var(--font-size-small);
+}
+</style>

--- a/src/talk/renderer/UserStatus/lastSeen.store.ts
+++ b/src/talk/renderer/UserStatus/lastSeen.store.ts
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useLastSeenStore = defineStore('lastSeen', () => {
+    const lastSeenMap = ref<Record<string, number | null>>({})
+
+    function setLastSeen(userId: string, timestamp: number | null) {
+        lastSeenMap.value[userId] = timestamp
+    }
+
+    function getLastSeen(userId: string): number | null {
+        return lastSeenMap.value[userId] ?? null
+    }
+
+    return {
+        lastSeenMap,
+        setLastSeen,
+        getLastSeen,
+    }
+})

--- a/src/talk/renderer/UserStatus/publicUserStatus.service.ts
+++ b/src/talk/renderer/UserStatus/publicUserStatus.service.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateOcsUrl } from '@nextcloud/router'
+
+// TODO: add types to @nextcloud/types or @nextcloud/axios
+interface OcsResponse<T> {
+    ocs: {
+        data: T
+    }
+}
+
+export type PublicUserStatusResponse = {
+    userId: string
+    status: string
+    message: string | null
+    icon: string | null
+    clearAt: number | null
+    lastSeen: number | null
+    statusTimestamp: number | null
+}
+
+/**
+ * Fetch public user status with last seen timestamp
+ *
+ * @param userId - User id
+ */
+export async function fetchUserLastSeen(userId: string): Promise<number | null> {
+    const response = await axios.get<OcsResponse<PublicUserStatusResponse>>(generateOcsUrl(`apps/user_status/api/v1/user_status?userId=${encodeURIComponent(userId)}&format=json`))
+    return response.data.ocs.data.lastSeen ?? response.data.ocs.data.statusTimestamp ?? null
+}

--- a/src/talk/renderer/UserStatus/useHeartbeat.ts
+++ b/src/talk/renderer/UserStatus/useHeartbeat.ts
@@ -5,8 +5,11 @@
 
 import { createSharedComposable } from '@vueuse/core'
 import { onBeforeUnmount, watch } from 'vue'
+import { getCurrentUser } from '@nextcloud/auth'
 import { useIsAway } from './composables/useIsAway.ts'
 import { useUserStatusStore } from './userStatus.store.ts'
+import { useLastSeenStore } from './lastSeen.store.ts'
+import { fetchUserLastSeen } from './publicUserStatus.service.ts'
 
 // General notes:
 // - Server has INVALIDATE_STATUS_THRESHOLD with 15 minutes, preventing immediate status update on heartbeat request
@@ -37,13 +40,19 @@ export const useHeartbeat = createSharedComposable(() => {
 	/**
 	 * Send a heartbeat
 	 */
-	async function heartbeat() {
-		try {
-			await userStatusStore.updateUserStatusWithHeartbeat(isAway.value)
-		} catch (error) {
-			console.error('Error on heartbeat:', error)
-		}
-	}
+       async function heartbeat() {
+               try {
+                       await userStatusStore.updateUserStatusWithHeartbeat(isAway.value)
+                       const current = getCurrentUser()
+                       if (current) {
+                               const lastSeenStore = useLastSeenStore()
+                               const lastSeen = await fetchUserLastSeen(current.uid)
+                               lastSeenStore.setLastSeen(current.uid, lastSeen)
+                       }
+               } catch (error) {
+                       console.error('Error on heartbeat:', error)
+               }
+       }
 
 	/**
 	 * Start heartbeat interval

--- a/src/talk/renderer/UserStatus/userStatus.types.ts
+++ b/src/talk/renderer/UserStatus/userStatus.types.ts
@@ -51,7 +51,10 @@ type UserStatusPredefined = UserStatusBase & {
 
 export type UserStatusPrivate = UserStatusCustom | UserStatusPredefined | UserStatusClean
 
-export type UserStatusPublic = Pick<UserStatusPrivate, 'userId' | 'message' | 'icon' | 'clearAt' | 'status'>
+export type UserStatusPublic = Pick<UserStatusPrivate, 'userId' | 'message' | 'icon' | 'clearAt' | 'status'> & {
+       /** Last seen timestamp in seconds */
+       lastSeen: number | null
+}
 
 export type UserStatus = UserStatusPrivate | UserStatusClean
 


### PR DESCRIPTION
## Summary
- fetch last-seen from user_status endpoint
- store last-seen timestamps per user
- update last-seen when opening a private conversation
- show relative last-seen info in a component
- refresh own last-seen via heartbeat
- add Russian translations

## Testing
- `npm run lint` *(fails: Cannot find package '@nextcloud/eslint-config')*
- `npm run typecheck` *(fails: vue-tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422213667483339a5c67520f04492b